### PR TITLE
fix:解决rundev时node不存在的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react18-demo",
   "version": "0.0.0",
   "scripts": {
-    "dev": "chokidar src/packages --initial --silent -c 'node ./bin/runDEV.js'",
+    "dev": "chokidar src/packages --initial --silent -c \"node ./bin/runDEV.js\"",
     "ssr": "node server",
     "build": "tsc && vite build",
     "serve": "vite preview"


### PR DESCRIPTION
解决chokidar-cli实际的命令行参数解析取决于所使用的操作系统和 shell: 为实现跨亚台兼容性，因为并非所有操作系统都普遍支持单引号，将run dev 内的命令修改为"chokidar src/packages --initial --silent -c \"node ./bin/runDEV.js\""。